### PR TITLE
fix/#108: 삭제된 아이디어의 즐겨찾기 정보가 조회되는 버그 수정

### DIFF
--- a/src/main/java/com/nexters/teambuilder/idea/service/IdeaService.java
+++ b/src/main/java/com/nexters/teambuilder/idea/service/IdeaService.java
@@ -2,6 +2,7 @@ package com.nexters.teambuilder.idea.service;
 
 import com.nexters.teambuilder.favorite.domain.Favorite;
 import com.nexters.teambuilder.favorite.domain.FavoriteRepository;
+import com.nexters.teambuilder.favorite.exception.FavoriteNotFoundException;
 import com.nexters.teambuilder.idea.api.dto.IdeaRequest;
 import com.nexters.teambuilder.idea.api.dto.IdeaResponse;
 import com.nexters.teambuilder.idea.domain.Idea;
@@ -136,6 +137,10 @@ public class IdeaService {
         if (!idea.getAuthor().getId().equals(author.getId())) {
             throw new IllegalArgumentException("해당 아이디어의 작성자가 아닙니다");
         }
+
+        Favorite favorite = favoriteRepository.findFavoriteByIdeaIdAndUuid(ideaId, author.getUuid())
+                .orElseThrow(() -> new FavoriteNotFoundException(ideaId));
+        favoriteRepository.delete(favorite);
 
         ideaRepository.delete(idea);
     }


### PR DESCRIPTION
즐겨찾기가 체크된 아이디어를 삭제해도 해당 즐겨찾기를 조회할 수 있는 문제를 수정했습니다.