### PR TITLE
Revert "fix: 즐겨찾기가 존재하지 않을 경우에도 정상적으로 아이디어 삭제"

### DIFF
--- a/src/main/java/com/nexters/teambuilder/idea/service/IdeaService.java
+++ b/src/main/java/com/nexters/teambuilder/idea/service/IdeaService.java
@@ -56,7 +56,7 @@ public class IdeaService {
             throw new UserNotActivatedException();
         }
 
-        if (!author.isSubmitIdea()) {
+        if(!author.isSubmitIdea()) {
             author.updateSubmitIdea(true);
             userRepository.save(author);
         }
@@ -140,7 +140,9 @@ public class IdeaService {
             throw new IllegalArgumentException("해당 아이디어의 작성자가 아닙니다");
         }
 
-        favoriteRepository.findFavoriteByIdeaIdAndUuid(ideaId, author.getUuid()).ifPresent(favoriteRepository::delete);
+        Favorite favorite = favoriteRepository.findFavoriteByIdeaIdAndUuid(ideaId, author.getUuid())
+                .orElseThrow(() -> new FavoriteNotFoundException(ideaId));
+        favoriteRepository.delete(favorite);
 
         ideaRepository.delete(idea);
     }


### PR DESCRIPTION
Reverts Nexters/team-builder-server#128

`No property existByIdeaId found for type Idea!` 에러 발생으로 revert
implement 하고 있는 JpaRepository에 define 되어있지 않아서 발생한 것으로 추정