### PR TITLE
Revert "issue/#111: 존재하지 않는 아이디어에 즐겨찾기가 추가되는 버그 수정"

### DIFF
--- a/src/main/java/com/nexters/teambuilder/favorite/service/FavoriteService.java
+++ b/src/main/java/com/nexters/teambuilder/favorite/service/FavoriteService.java
@@ -35,7 +35,7 @@ public class FavoriteService {
     }
 
     public FavoriteResponse createFavorite(User user, FavoriteRequest request) {
-        if(!ideaRepository.existByIdeaId(request.getIdeaId())){
+        if(!ideaRepository.findByIdeaId(request.getIdeaId())){
             throw new IdeaNotFoundException(request.getIdeaId());
         }
 

--- a/src/main/java/com/nexters/teambuilder/idea/domain/IdeaRepository.java
+++ b/src/main/java/com/nexters/teambuilder/idea/domain/IdeaRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface IdeaRepository extends JpaRepository<Idea, Integer> {
     List<Idea> findAllBySessionSessionId(Integer sessionId);
     List<Idea> findAllByIdeaIdIn(List<Integer> ideaIds);
-    boolean existByIdeaId(Integer ideaId);
+    boolean findByIdeaId(Integer ideaId);
 }


### PR DESCRIPTION
Reverts Nexters/team-builder-server#118

`No property existByIdeaId found for type Idea` 에러 발생으로 revert
implement 하고 있는 JpaRepository에 define 되어있지 않아서 발생한 것으로 추정

JpaRepository가 상속하는 클래스에 exists가 있던데 이걸 써도 같은 오류가 나더라구요.
exist 대신 find로 처리했는데 괜찮은지 확인 부탁드려요!